### PR TITLE
Fix up requirements for python>3.10

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,9 @@
+certifi==2025.6.15
+charset-normalizer==3.4.2
+idna==3.10
+oauthlib==3.3.0
 pytz==2020.5
+requests==2.32.4
 requests-oauthlib==1.3.0
-tabulate==0.8.7
+tabulate==0.9.0
+urllib3==2.5.0


### PR DESCRIPTION
Running the script against a python version >3.10 runs into https://github.com/astanin/python-tabulate/pull/105 which is fixed in the latest version of tabular.

Commands for updating:
$ pip install --upgrade tabular
$ pip freeze > requirements.txt
